### PR TITLE
修复链接字符串遗漏库名认证失败问题

### DIFF
--- a/src/MongoDBLibrary/mongo_connection_manager.py
+++ b/src/MongoDBLibrary/mongo_connection_manager.py
@@ -23,7 +23,7 @@ class MongoConnectionManager(object):
         | # To connect to foo.bar.org's MongoDB service on port 27017 |
         | Connect To MongoDB | foo.bar.org | ${27017} |
         | # Or for an authenticated connection, note addtion of "mongodb://" to host uri |
-        | Connect To MongoDB | mongodb://admin:admin@foo.bar.org | ${27017} |
+        | Connect To MongoDB | mongodb://admin:admin@foo.bar.org/dbName | ${27017} |
         
         """
         dbapiModuleName = 'pymongo'


### PR DESCRIPTION
链接关键字的说明文档中，链接字符串缺少库名，数据库操作时会提示认证失败